### PR TITLE
Update test_workload.yml - fix linting (spaces)

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_rhoso_ipam4lab/examples/test_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_rhoso_ipam4lab/examples/test_workload.yml
@@ -9,12 +9,12 @@
     # Required variables
     ocp4_workload_rhoso_ipam4lab_service_url: "https://ipam4lab-ipam4lab.apps.cluster.example.com"
     ocp4_workload_rhoso_ipam4lab_cluster_name: "test-cluster"
-    
+
     # Optional variables
     ocp4_workload_rhoso_ipam4lab_allocation_name: "rhoso-lab-{{ ansible_date_time.epoch }}"
     ocp4_workload_rhoso_ipam4lab_request_timeout: 30
     ocp4_workload_rhoso_ipam4lab_include_raw_response: true
-    
+
     # Control variables
     ACTION: "create"  # Use "destroy" to deallocate
     silent: false


### PR DESCRIPTION
/home/runner/work/agnosticd/agnosticd/ansible/roles_ocp_workloads/ocp4_workload_rhoso_ipam4lab/examples/test_workload.yml
  12:1      error    trailing spaces  (trailing-spaces)
  17:1      error    trailing spaces  (trailing-spaces)
